### PR TITLE
Remove a stupid line that makes it load WAY faster.

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,7 +122,6 @@ class BadgeChange(db.Model):
 
 class MainHandler(webapp.RequestHandler):
     def get(self):
-        signup_users = Membership.all().fetch(10000)
         template_values = {
             'plan': self.request.get('plan', 'newfull'),
             'paypal': self.request.get('paypal')}


### PR DESCRIPTION
It appeared to be a remnant left over from when we needed all the
member information for the "referred by" thing. Anyway, that
should stop the page from taking a frustratingly long time to
load.